### PR TITLE
Fix failing test suite: restore sorry placeholders in example problems

### DIFF
--- a/examples/basic_algebra.lean
+++ b/examples/basic_algebra.lean
@@ -1,11 +1,13 @@
+-- Basic algebraic identities for testing the Erdos solver
+
 theorem add_comm (a b : Nat) : a + b = b + a := by
-  exact Nat.add_comm a b
+  sorry
 
 theorem mul_one (n : Nat) : n * 1 = n := by
-  exact Nat.mul_one n
+  sorry
 
 theorem add_zero (n : Nat) : n + 0 = n := by
-  exact Nat.add_zero n
+  sorry
 
 theorem mul_comm (a b : Nat) : a * b = b * a := by
-  exact Nat.mul_comm a b
+  sorry

--- a/examples/intermediate.lean
+++ b/examples/intermediate.lean
@@ -1,17 +1,19 @@
+-- Intermediate theorems requiring induction, cases, or omega
+
 theorem nat_add_assoc (a b c : Nat) : (a + b) + c = a + (b + c) := by
-  exact Nat.add_assoc a b c
+  sorry
 
 theorem nat_mul_zero (n : Nat) : n * 0 = 0 := by
-  exact Nat.mul_zero n
+  sorry
 
 theorem nat_succ_ne_zero (n : Nat) : n + 1 ≠ 0 := by
-  simpa using Nat.succ_ne_zero n
+  sorry
 
 theorem bool_and_comm (a b : Bool) : (a && b) = (b && a) := by
-  cases a <;> cases b <;> rfl
+  sorry
 
 theorem list_length_nil : ([] : List Nat).length = 0 := by
-  rfl
+  sorry
 
 theorem nat_le_succ (n : Nat) : n ≤ n + 1 := by
-  simpa using Nat.le_succ n
+  sorry

--- a/examples/number_theory.lean
+++ b/examples/number_theory.lean
@@ -1,17 +1,13 @@
+-- Elementary number theory problems
+
 theorem succ_pos (n : Nat) : 0 < n + 1 := by
-  simpa [Nat.succ_eq_add_one] using Nat.succ_pos n
+  sorry
 
 theorem le_refl (n : Nat) : n <= n := by
-  exact Nat.le_refl n
+  sorry
 
 theorem add_le_add_left (a b c : Nat) (h : a <= b) : c + a <= c + b := by
-  exact Nat.add_le_add_left h c
+  sorry
 
 theorem nat_zero_or_succ (n : Nat) : n = 0 ∨ ∃ m, n = m + 1 := by
-  cases n with
-  | zero =>
-      left
-      rfl
-  | succ m =>
-      right
-      exact ⟨m, rfl⟩
+  sorry

--- a/examples/test_theorem.lean
+++ b/examples/test_theorem.lean
@@ -1,2 +1,5 @@
+-- Example theorem with 'sorry' for testing
+-- This is a trivial theorem that should be solvable
+
 theorem one_plus_one : 1 + 1 = 2 := by
-  rfl
+  sorry


### PR DESCRIPTION
## What

Restores the unsolved (`sorry`-placeholder) versions of the four example problem files in `examples/`. The test suite on `main` currently fails with **14 failed / 300 passed**; with this change it's **314 passed, 9 skipped**.

## Why

PR #27 added `tests/test_operational.py`, which asserts that example problem files contain `sorry` placeholders (`test_original_content_is_preloaded`, `test_intermediate_has_sorry_placeholders`). But the same PR committed the example files with **completed proofs** — solver output evidently leaked into the working tree before commit. The tests it added have been failing ever since.

Solved example files also defeat the project's premise: problems must ship unsolved for the Prover/Critic loop (and the README's mock-mode demo) to have anything to prove.

## Changes

- `examples/test_theorem.lean`, `examples/basic_algebra.lean`, `examples/number_theory.lean`: restored verbatim to their pre-#27 versions (from commit `970c3a8`).
- `examples/intermediate.lean`: this file was *introduced* by #27 already solved, so there's no prior version — its six theorem statements are kept and each proof body replaced with `sorry` (6 ≥ the 5 the test requires).

## Verification

- `python -m pytest tests/ -q` → 314 passed, 9 skipped (the 9 skips are environment-gated and unchanged from before).
- Confirmed the solver writes solutions to a separate work dir (`solution_<id>.json` + ZIP), never back into `examples/`, so the current code won't re-introduce this.

## Notes for the maintainer

1. The other 12 failures I saw locally (`TestGeminiProvider`, provider factory) were a broken `cffi` wheel in my container, not a code issue — `google-generativeai` imports fine after reinstalling `cffi`, and CI installs it cleanly via pyproject deps.
2. **GitHub Actions has zero workflow runs** for this repo, despite `.github/workflows/ci.yml` being configured for pushes/PRs to `main` and the README sporting a CI badge. That's why this breakage went unnoticed. Worth checking **Settings → Actions** to confirm Actions is enabled — once it is, this PR should get a CI run.

https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN)_