### PR TITLE
CI: fix workflows to pass on first activation; make release spec actually build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-latest
+          # Build on ubuntu-22.04 (not -latest) so the PyInstaller binary's
+          # glibc baseline matches the ubuntu-22.04 Tauri bundle that ships it.
+          - platform: ubuntu-22.04
             artifact: erdos-solver-linux
             binary: dist/erdos-solver
           - platform: windows-latest
@@ -52,10 +54,12 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
+        # Install every optional provider SDK so the bundled sidecar ships
+        # with full multi-provider support (OpenAI, Anthropic, Google, Ollama).
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          pip install -e "."
+          pip install -e ".[all]" "google-generativeai>=0.8.0"
 
       - name: Build Python executable
         run: pyinstaller erdos-solver.spec
@@ -68,6 +72,8 @@ jobs:
 
   build-tauri:
     needs: [test, build-python]
+    permissions:
+      contents: write  # tauri-action creates the draft release
     strategy:
       fail-fast: false
       matrix:
@@ -98,7 +104,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
       - name: Download Python sidecar
         uses: actions/download-artifact@v4
@@ -106,9 +112,18 @@ jobs:
           name: ${{ matrix.python-artifact }}
           path: gui/src-tauri/binaries
 
-      - name: Make sidecar executable (Unix)
-        if: matrix.platform != 'windows-latest'
-        run: chmod +x gui/src-tauri/binaries/${{ matrix.sidecar-name }}
+      - name: Rename sidecar to target triple
+        # Tauri resolves `externalBin` entries as <name>-<target-triple>[.exe]
+        shell: bash
+        working-directory: gui/src-tauri/binaries
+        run: |
+          host_triple="$(rustc -Vv | sed -n 's/^host: //p')"
+          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            mv "${{ matrix.sidecar-name }}" "erdos-solver-${host_triple}.exe"
+          else
+            mv "${{ matrix.sidecar-name }}" "erdos-solver-${host_triple}"
+            chmod +x "erdos-solver-${host_triple}"
+          fi
 
       - name: Install frontend dependencies
         working-directory: gui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
 
   rust-tests:
     name: Rust Tests
-    runs-on: ubuntu-latest
+    # Tauri v1 links against webkit2gtk-4.0, which no longer exists on
+    # Ubuntu 24.04 (ubuntu-latest). Stay on 22.04 until the GUI moves to
+    # Tauri v2 / webkit2gtk-4.1.
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -50,11 +53,24 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Create stub frontend dist and sidecar
+        # tauri-build resolves `distDir` and `externalBin` at compile time,
+        # but both are gitignored build outputs. Stub them so cargo can
+        # compile without a frontend/PyInstaller build (build.yml exercises
+        # the real artifacts).
+        run: |
+          mkdir -p gui/dist gui/src-tauri/binaries
+          host_triple="$(rustc -Vv | sed -n 's/^host: //p')"
+          touch "gui/src-tauri/binaries/erdos-solver-${host_triple}"
+          chmod +x "gui/src-tauri/binaries/erdos-solver-${host_triple}"
 
       - name: Check Rust formatting
         working-directory: gui/src-tauri

--- a/erdos-solver.spec
+++ b/erdos-solver.spec
@@ -6,8 +6,23 @@ The resulting binary is used as a Tauri sidecar — the GUI launches it as a
 subprocess and communicates via JSON Lines on stdout.
 """
 
-import sys
+import os
+
 from PyInstaller.utils.hooks import collect_submodules
+
+# src/solver.py uses package-relative imports, so it cannot be the entry
+# script itself (PyInstaller runs the entry script as __main__, which has no
+# parent package). Generate a tiny absolute-import launcher in the build
+# workpath instead. `workpath` and `SPECPATH` are provided by PyInstaller.
+os.makedirs(workpath, exist_ok=True)
+launcher = os.path.join(workpath, 'erdos-solver-launcher.py')
+with open(launcher, 'w', encoding='utf-8') as f:
+    f.write(
+        'from src.solver import main\n'
+        '\n'
+        'if __name__ == "__main__":\n'
+        '    main()\n'
+    )
 
 # Collect all submodules for providers that use dynamic imports
 hidden_imports = [
@@ -26,8 +41,10 @@ hidden_imports = [
     'src.llm',
     'src.llm.factory',
     'src.llm.base',
+    'src.llm.mock',
     'src.llm.openai_provider',
     'src.llm.anthropic_provider',
+    'src.llm.chatgpt_provider',
     'src.llm.gemini',
     'src.llm.ollama_provider',
     # Third-party with dynamic imports
@@ -55,8 +72,8 @@ except Exception:
     pass
 
 a = Analysis(
-    ['src/solver.py'],
-    pathex=['.'],
+    [launcher],
+    pathex=[SPECPATH],
     binaries=[],
     datas=[
         ('manifest.json', '.'),


### PR DESCRIPTION
## What

Repairs both workflows so they pass the first time Actions is enabled, and fixes the PyInstaller spec so the release pipeline produces a working binary.

- **ci.yml**: rust-tests pinned to ubuntu-22.04 (Tauri v1 needs webkit2gtk-4.0, gone on 24.04); stubs `gui/dist` and the target-triple sidecar so `tauri-build` can compile without frontend artifacts; adds rustfmt/clippy components and ayatana-appindicator dev libs.
- **build.yml**: renames the PyInstaller sidecar to Tauri's required `<name>-<target-triple>[.exe]` form before bundling (it would not have been found otherwise); Linux sidecar built on ubuntu-22.04 to match the bundle's glibc baseline; installs all provider SDKs into the sidecar; grants `contents: write` for tauri-action's draft release.
- **erdos-solver.spec**: generated launcher entry point so package-relative imports work frozen; missing hidden imports added (`src.llm.mock`, `src.llm.chatgpt_provider`).

## Verification

- All workflow YAML parses.
- `pyinstaller erdos-solver.spec` run locally: build succeeds and `dist/erdos-solver --help` works in mock mode.

⚠️ **Owner action still required:** GitHub Actions has zero runs ever on this repo — enable it under **Settings → Actions** so these workflows (and the README badge) come alive.

Part of the project-wide polish batch.

https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN)_