### PR TITLE
Docs: accuracy pass, OpenRouter story, remote-manifest documentation, hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ solutions/
 
 # Testing
 .pytest_cache/
+.coverage
+.coverage.*
 coverage.xml
 htmlcov/
 

--- a/ASSESSMENT.md
+++ b/ASSESSMENT.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-10
 **Assessor:** Independent automated review (Claude)
-**Method:** Installed Lean 4.28.0, wrote 145+ tests (66 wiring + 30 real-data + 20 bug fix demos + 16 operational), compiled real theorems against Lean compiler, tested full pipeline end-to-end, fixed 4 critical bugs + 7 operational gaps, added LLM isolation architecture
+**Method:** Installed Lean 4.28.0, wrote 125+ tests (66 wiring + 30 real-data + 16 bug fix demos + 16 operational), compiled real theorems against Lean compiler, tested full pipeline end-to-end, fixed 4 critical bugs + 7 operational gaps, added LLM isolation architecture
 
 ---
 
@@ -183,7 +183,7 @@ After the 4 critical bug fixes above, 7 additional operational gaps were identif
 - `src/llm/factory.py` — Pass `OPENAI_REASONING_EFFORT` env var
 
 ### Tests
-- `tests/test_bug_fix_demos.py` — 20 visual proof demo tests (NEW)
+- `tests/test_bug_fix_demos.py` — 16 visual proof demo tests (NEW)
 - `tests/test_independent_assessment.py` — 66 wiring verification tests
 - `tests/test_real_data_validation.py` — 30 real-data tests with Lean compiler
 - `tests/test_operational.py` — 16 operational tests for all 7 fixes (NEW)

--- a/Plan.md
+++ b/Plan.md
@@ -1,5 +1,7 @@
 # Erdos Proof Mining System
 
+> **Status (2026-06-10):** This is the original design document, kept as-written for the record. What's actually shipped: the Prover/Critic solver loop (`src/solver.py`), SHA-256 theorem locking and security validation (`src/validator.py`), isolated Lean build sandbox (`src/sandbox.py`), elan/Lean environment manager with repo cloning and `lake update` handling (`src/environment.py`), remote manifest fetching with caching (`src/manifest.py`), campaign history (`src/campaign.py`), solution ZIP packager with local index (`src/packager.py`), the LLM provider factory (OpenRouter, Gemini, OpenAI, Anthropic, Ollama, mock), the Tauri GUI (`gui/`), and CI workflows (`.github/workflows/`). Still aspirational: automatic submission of proof artifacts to a remote branch or API endpoint (section 3.5 — the packager only writes local ZIPs), enforcement of `min_app_version` (parsed but not acted on), app auto-update, process-level sandbox permission restrictions (isolation is file-level), and published installer artifacts (build workflow exists; no public releases yet).
+
 ## 1. Executive Summary
 
 **Objective:** Create a consumer-grade desktop application that utilizes user-provided compute and API credits to solve formalized mathematical conjectures in Lean 4.

--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@ Multi-agent theorem prover. LLM agents write Lean 4 proofs. SHA-256 integrity lo
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+**Project page:** [cuuper22.github.io/Erdos](https://cuuper22.github.io/Erdos/)
+
 ## What makes this different
 
 Most LLM theorem provers trust the model's output. Erdos doesn't - it hashes theorem statements before the loop starts and rejects any attempt that modifies what's being proved.
 
 The Prover/Critic architecture is adversarial by design. One model tries to prove, another tries to break the proof. The Lean compiler is the arbiter neither agent can influence.
 
-It supports multiple LLM backends - Gemini, OpenAI, Anthropic, Ollama (local), or mock mode for testing. No vendor lock-in.
+It supports multiple LLM backends - OpenRouter (recommended: one key, any model), direct Gemini, OpenAI, Anthropic, Ollama (local), or mock mode for testing. No vendor lock-in.
 
 It ships as a desktop app. Tauri GUI with settings panel, log viewer, cost tracking, and proof gallery. Or just use the CLI.
 
-It's a single-person project with 323 test functions across 13 test files. CI is configured for Python 3.10-3.12 plus Rust build/test checks for the GUI. Not a research lab with a team of 20.
+It's a single-person project with 320+ test functions across 14 test files. CI is configured for Python 3.10-3.12 plus Rust build/test checks for the GUI. Not a research lab with a team of 20.
 
 ## How to inspect it
 
@@ -83,9 +85,11 @@ python -m src.environment --install
 ### Set an API key
 
 ```bash
-export GOOGLE_API_KEY="your-key"
-# Or: OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_URL for local models
+export OPENROUTER_API_KEY="your-key"   # recommended: one key, any model
+# Or: GOOGLE_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, OLLAMA_URL for local models
 ```
+
+The direct Gemini path uses the deprecated `google-generativeai` SDK, so it ships as an optional extra: `pip install -e ".[gemini]"`.
 
 ### Run
 
@@ -140,13 +144,16 @@ All implemented, auto-detected from environment variables:
 
 | Provider | Env Var | Default Model |
 |----------|---------|---------------|
+| OpenRouter (recommended) | `OPENROUTER_API_KEY` | google/gemini-2.5-flash |
 | Google Gemini | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | gemini-3-flash |
 | OpenAI | `OPENAI_API_KEY` | gpt-4o |
 | Anthropic | `ANTHROPIC_API_KEY` | claude-sonnet-4-20250514 |
 | Ollama (local) | `OLLAMA_URL` | llama3.2 |
 | Mock (testing) | `ERDOS_MOCK_MODE=1` | n/a |
 
-Override model: `export LLM_MODEL="gemini-3-pro"`
+OpenRouter is the path of least resistance: one key, any model on their catalog. The direct Gemini provider depends on the deprecated `google-generativeai` SDK, packaged as the `gemini` extra.
+
+Override model: `export LLM_MODEL="google/gemini-2.5-pro"`
 
 ## Configuration
 
@@ -155,7 +162,7 @@ Env vars: `LLM_MODEL`, `MAX_COST_USD`, `MAX_RETRIES`, `BUILD_TIMEOUT`.
 Or `config.json`:
 ```json
 {
-  "llm": { "provider": "google", "model": "gemini-3-flash", "temperature_prover": 0.7, "temperature_critic": 0.1 },
+  "llm": { "provider": "openrouter", "model": "google/gemini-2.5-flash", "temperature_prover": 0.7, "temperature_critic": 0.1 },
   "cost": { "max_cost_usd": 5.0 },
   "solver": { "max_retries": 10, "build_timeout_seconds": 60 }
 }
@@ -177,15 +184,17 @@ Erdos/
 │   ├── events.py               # JSON Lines event system
 │   └── llm/                    # LLM provider factory
 │       ├── factory.py          # Auto-detection from env vars
-│       ├── gemini.py           # Google Gemini
+│       ├── openrouter_provider.py # OpenRouter (recommended: one key, any model)
+│       ├── gemini.py           # Google Gemini (optional `gemini` extra)
 │       ├── openai_provider.py  # OpenAI
 │       ├── anthropic_provider.py # Anthropic
 │       └── ollama_provider.py  # Ollama (local)
 ├── gui/                        # Tauri desktop app
 │   ├── src/                    # React frontend
 │   └── src-tauri/              # Rust backend (IPC, process management)
-├── tests/                      # 323 test functions across 13 test files
-├── manifest.json               # Problem queue
+├── tests/                      # 320+ test functions across 14 test files
+├── manifest.json               # Problem queue (local example problems)
+├── manifest.remote.json        # Sample remote-campaign manifest format (not consumed by code)
 └── .github/workflows/          # CI: pytest (3.10-3.12) + Rust build/test + linting
 ```
 
@@ -195,7 +204,7 @@ Erdos/
 pytest tests/ -v
 ```
 
-323 test functions across 13 test files:
+320+ test functions across 14 test files:
 
 | Module | What it covers |
 |--------|---------------|
@@ -204,7 +213,8 @@ pytest tests/ -v
 | test_independent_assessment.py | Wiring assessment for validator, sandbox, solver, parser, provider, and packager behavior |
 | test_bug_fix_demos.py | Regression demos for axiom abuse, elan discovery, sorry replacement, cache behavior, feedback isolation |
 | test_operational.py | Manifest resolution, pre-flight setup, mock-mode warnings, intermediate examples |
-| test_llm_providers.py | All 5 LLM backends - init, generate, retry, error handling |
+| test_llm_providers.py | Gemini, OpenAI, Anthropic, Ollama, and mock backends - init, generate, retry, error handling |
+| test_openrouter.py | OpenRouter provider - init, model selection, error handling |
 | test_environment.py | Lean toolchain management, caching, cleanup |
 | test_manifest.py | Remote fetching, caching, merging, URL conversion |
 | test_campaign.py | Problem history, prioritization, persistence |
@@ -213,7 +223,7 @@ pytest tests/ -v
 | test_events.py | Event emission, JSON formatting |
 | test_solver.py | Prover/Critic initialization, manifest loading |
 
-CI runs on every push: Python 3.10-3.12 matrix with coverage, Rust build/test checks, flake8, and black formatting checks.
+CI runs on pushes and pull requests: Python 3.10-3.12 matrix with coverage, Rust build/test checks, flake8, and black formatting checks.
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,11 +2,15 @@
 
 This directory contains sample Lean 4 theorem proving problems for testing the Erdos solver.
 
+These files are intentionally **unsolved**: every theorem ends in a `sorry` placeholder. That is the input format the solver expects — it replaces the `sorry` with a candidate proof, compiles it, and validates the result. Do not commit completed proofs here; a solved example would give the solver nothing to do (and `sorry` is only banned in LLM *output*, not in the original problem files).
+
 ## Files
 
 - `test_theorem.lean` - Basic arithmetic theorem
 - `basic_algebra.lean` - Simple algebraic identities
 - `number_theory.lean` - Elementary number theory problems
+- `intermediate.lean` - Moderately challenging theorems (induction, cases, omega)
+- `manifest.json` - Problem queue entries for the files above
 
 ## Usage
 
@@ -28,6 +32,10 @@ python -m src.solver --manifest examples/manifest.json
 
 ## Adding New Problems
 
-1. Create a new `.lean` file with your theorem
+1. Create a new `.lean` file with your theorem statement, leaving the proof as `sorry`
 2. Add an entry to `examples/manifest.json`
 3. Test with the solver
+
+## Related manifests
+
+The root `manifest.json` points at these same example files, so `python -m src.solver --manifest manifest.json` works out of the box. The root `manifest.remote.json` is different: it is a preserved sample of the remote "campaign" manifest format (referencing `FormalConjectures/Erdos/*.lean` paths from the google-deepmind/formal-conjectures repository, which is not vendored here). Nothing in `src/` reads it — keep it as a format reference for future remote campaigns.

--- a/manifest.remote.json
+++ b/manifest.remote.json
@@ -26,5 +26,5 @@
     "url": "https://github.com/google-deepmind/formal-conjectures",
     "branch": "main"
   },
-  "_note": "This manifest requires cloning the remote repository first. Use manifest.json for local examples."
+  "_note": "Sample of the remote 'campaign' manifest format. The FormalConjectures/* paths live in the google-deepmind/formal-conjectures repository, which is not vendored here - clone it first (src/environment.py can do this). Nothing in src/ reads this file; use manifest.json for the local examples."
 }


### PR DESCRIPTION
## What

Docs accuracy pass and repo hygiene, written to reflect the full batch landing together.

- README: stale counts corrected, provider story updated for OpenRouter-as-default (with the Gemini SDK as the `[gemini]` extra), project-page link added, paths re-verified.
- `manifest.remote.json` documented truthfully as the remote-campaign sample format.
- `Plan.md` gains a dated status header (shipped vs aspirational); `ASSESSMENT.md` factual refs fixed only.
- `examples/README.md` matches the restored unsolved (`sorry`) example state.
- `.gitignore`: runtime outputs (work dirs, solutions, coverage) covered.

Part of the project-wide polish batch.

https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN)_