### PR TITLE
Verify end-to-end against real Lean 4.30.0; fix installer and ELAN_HOME bugs

### DIFF
--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -1,0 +1,100 @@
+# End-to-End Verification Report
+
+**Date:** 2026-06-10
+**Environment:** Linux container (Ubuntu 24.04 base), Python 3.12, no prior Lean toolchain, `release.lean-lang.org` blocked by network policy, `github.com` reachable.
+
+This report documents a real end-to-end verification of the Erdos pipeline
+against an actual Lean 4 compiler — not mocks. Everything below was executed,
+not inferred.
+
+---
+
+## What was verified
+
+### 1. Toolchain installation via the project's own installer
+
+`python -m src.environment --install`
+
+- elan 4.1.2 installed to the app-isolated `~/.erdos-prover/bin/elan/` —
+  worked out of the box after splitting binary install from toolchain
+  install (`--default-toolchain none`).
+- `elan toolchain install stable` **failed** on this network:
+  elan fetches channel metadata from `release.lean-lang.org`, which is
+  blocked here (returns an HTML error page → elan: "Unexpected character:
+  H at (1:1)"). This will affect any locked-down network.
+- **Fix shipped:** `_install_toolchain_from_github()` in
+  `src/environment.py` — resolves the latest release tag via the GitHub
+  `releases/latest` redirect (no API token), downloads the official
+  `lean-X.Y.Z-linux.zip` (826 MB), extracts it preserving Unix permission
+  bits (Python's `ZipFile.extractall` drops the executable bit — see
+  `_extract_zip_with_permissions`), and registers it with
+  `elan toolchain link` + `elan default`.
+- Result: **Lean 4.30.0 installed and functional** (`lean --version`,
+  `lake init`, `lake build` all verified).
+
+### 2. Bug found: elan proxies need `ELAN_HOME`, not just `PATH`
+
+`src/sandbox.py` prepended the discovered elan bin directory to `PATH`
+but never set `ELAN_HOME`. The elan proxy binaries (`lean`, `lake`)
+resolve toolchains relative to `ELAN_HOME`, defaulting to `~/.elan` —
+so with the app-isolated install the proxies failed with
+"no default toolchain configured" even though `lake` was on `PATH`.
+
+**Fix:** `_elan_env()` in `src/sandbox.py` builds the subprocess
+environment with both `PATH` and `ELAN_HOME` derived from the discovered
+install; used by `_init_lean_project()` and `run_lake_build()`.
+`tests/test_real_data_validation.py` previously hardcoded `~/.elan/bin`
+and now uses the same discovery, so the Lean-gated tests run against
+whichever install exists.
+
+### 3. The 9 formerly-skipped real-compilation tests
+
+Before: `314 passed, 9 skipped` (skip reason: "Lean not installed").
+After: **`323 passed, 0 skipped`** (8.9 s).
+
+The now-executing tests verify, against the real compiler:
+
+- a known-correct proof compiles (`test_correct_proof_compiles`)
+- `sorry` compiles with a warning, and the validator still rejects it
+- a wrong proof fails to compile (compiler as arbiter)
+- a proof of a *modified* theorem compiles but is rejected by the
+  SHA-256 theorem lock (the core anti-specification-gaming property,
+  proven against real Lean output)
+- the full pipeline — provider → integrity check → real `lake build` →
+  critic → packaged artifact — succeeds end to end
+  (`test_correct_provider_full_pipeline`)
+- mock-mode output does **not** compile (mock is scaffolding, see below)
+
+### 4. Mock-mode end-to-end run
+
+`ERDOS_MOCK_MODE=1 python -m src.solver --manifest manifest.json`
+
+- Lean pre-flight passes; all 4 example problems are attempted.
+- Every attempt stops at the integrity gate: the mock provider's canned
+  response still contains `sorry`, which is banned in candidates
+  (`mining_complete: total_problems=4, solved=0, failed=4`).
+- This is **by design** (the suite asserts mock output must not produce
+  a valid proof) — mock mode exercises the loop, integrity checking,
+  retry, and budget accounting without an API key; it does not
+  demonstrate a solve. The end-to-end *success* path is covered by
+  `test_correct_provider_full_pipeline` above.
+
+---
+
+## Not verified here
+
+- Real LLM API calls (OpenRouter/OpenAI/Anthropic/Gemini/Ollama) — needs
+  keys; the provider layer is covered by mocked tests.
+- Windows and macOS installer paths (`elan-init.ps1`, `.tar.zst` assets) —
+  the GitHub fallback downloads `.zip` assets, which lean4 publishes for
+  all three platforms, but only Linux was executed.
+- Tauri GUI ↔ sidecar integration (covered separately by the GUI build
+  verification).
+
+## How to reproduce locally
+
+```bash
+python -m src.environment --install   # installs elan + Lean (GitHub fallback if needed)
+python -m pytest tests/ -q            # expect: 323 passed, 0 skipped
+ERDOS_MOCK_MODE=1 python -m src.solver --manifest manifest.json
+```

--- a/src/environment.py
+++ b/src/environment.py
@@ -14,10 +14,12 @@ import hashlib
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import time
 import urllib.request
+import zipfile
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -79,6 +81,21 @@ def _download_with_progress(
     logger.info(f"{label}: complete ({downloaded} bytes)")
 
 
+def _extract_zip_with_permissions(archive: Path, dest: Path) -> None:
+    """Extract a ZIP archive, restoring Unix permission bits.
+
+    Python's ZipFile.extractall drops the executable bit, which breaks
+    extracted toolchain binaries (lean, lake). This restores the mode
+    stored in each entry's external attributes.
+    """
+    with zipfile.ZipFile(archive) as zf:
+        for info in zf.infolist():
+            extracted = Path(zf.extract(info, dest))
+            mode = (info.external_attr >> 16) & 0o7777
+            if mode:
+                extracted.chmod(mode)
+
+
 def _verify_checksum(file_path: Path, expected_sha256: str) -> bool:
     """Verify SHA-256 checksum of a file."""
     h = hashlib.sha256()
@@ -107,6 +124,10 @@ class EnvironmentManager:
 
     ELAN_UNIX_URL = "https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh"
     ELAN_WINDOWS_URL = "https://raw.githubusercontent.com/leanprover/elan/master/elan-init.ps1"
+
+    # Official lean4 release archives (toolchain fallback for networks
+    # where release.lean-lang.org is unreachable but github.com is)
+    LEAN4_RELEASES_URL = "https://github.com/leanprover/lean4/releases"
 
     # Cache file for toolchain state
     TOOLCHAIN_CACHE_FILE = "toolchain_cache.json"
@@ -248,8 +269,11 @@ class EnvironmentManager:
         env = os.environ.copy()
         env["ELAN_HOME"] = str(elan_home)
 
+        # --default-toolchain none: only install the elan binary here.
+        # The toolchain itself is installed separately (install_lean_toolchain),
+        # so a slow or failed toolchain download can't fail the elan install.
         result = subprocess.run(
-            [str(installer_path), "-y", "--no-modify-path"],
+            [str(installer_path), "-y", "--no-modify-path", "--default-toolchain", "none"],
             env=env,
             capture_output=True,
             text=True,
@@ -289,11 +313,14 @@ class EnvironmentManager:
         # Quote paths for spaces in usernames
         ps1_path = str(installer_path)
 
+        # -DefaultToolchain none: only install the elan binary here (the
+        # toolchain is installed separately via install_lean_toolchain).
         result = subprocess.run(
             [
                 "powershell", "-ExecutionPolicy", "Bypass",
                 "-File", ps1_path,
                 "-NoPrompt", "-NoModifyPath",
+                "-DefaultToolchain", "none",
             ],
             env=env,
             capture_output=True,
@@ -330,7 +357,13 @@ class EnvironmentManager:
     # ── Toolchain management ──
 
     def install_lean_toolchain(self, toolchain: str = "stable") -> bool:
-        """Install a specific Lean toolchain via elan."""
+        """Install a specific Lean toolchain via elan.
+
+        If elan's normal install path fails (it resolves channels and fetches
+        toolchains via release.lean-lang.org, which some networks block),
+        falls back to downloading the release archive directly from GitHub
+        and registering it with `elan toolchain link`.
+        """
         logger.info(f"Installing Lean toolchain: {toolchain}")
 
         try:
@@ -345,12 +378,118 @@ class EnvironmentManager:
             if result.returncode == 0:
                 logger.info(f"Toolchain {toolchain} installed successfully")
                 return True
-            else:
-                logger.error(f"Failed to install toolchain: {result.stderr}")
-                return False
+
+            logger.error(f"Failed to install toolchain: {result.stderr}")
+            logger.info("Trying direct GitHub release fallback...")
+            return self._install_toolchain_from_github(toolchain)
+        except FileNotFoundError:
+            logger.error("elan not found; install elan first")
+            return False
         except Exception as e:
             logger.error(f"Error installing toolchain: {e}")
             return False
+
+    def _resolve_latest_lean_version(self) -> Optional[str]:
+        """Resolve the latest stable lean4 version tag (e.g. 'v4.30.0').
+
+        Follows the GitHub /releases/latest redirect, which needs no API
+        token and is not rate-limited like the REST API.
+        """
+        url = f"{self.LEAN4_RELEASES_URL}/latest"
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                final_url = resp.geturl()
+        except Exception as e:
+            logger.error(f"Could not resolve latest Lean version: {e}")
+            return None
+
+        tag = final_url.rstrip("/").split("/")[-1]
+        if re.fullmatch(r"v\d+\.\d+\.\d+(-rc\d+)?", tag):
+            return tag
+        logger.error(f"Unexpected redirect target for latest release: {final_url}")
+        return None
+
+    @staticmethod
+    def _parse_lean4_version(toolchain: str) -> Optional[str]:
+        """Extract a pinned lean4 version tag from a toolchain spec.
+
+        Returns 'vX.Y.Z' for 'stable'-resolved or pinned official toolchains,
+        or None for specs the GitHub fallback cannot serve (nightlies, forks).
+        """
+        spec = toolchain.strip()
+        if ":" in spec:
+            origin, _, spec = spec.partition(":")
+            if origin != "leanprover/lean4":
+                return None
+        if re.fullmatch(r"v\d+\.\d+\.\d+(-rc\d+)?", spec):
+            return spec
+        return None
+
+    def _install_toolchain_from_github(self, toolchain: str = "stable") -> bool:
+        """Install a Lean toolchain from a GitHub release archive.
+
+        Downloads the official lean4 release ZIP for this platform, extracts
+        it under the app directory, and registers it via `elan toolchain
+        link` + `elan default`. Works on networks where release.lean-lang.org
+        is unreachable but github.com is.
+        """
+        if toolchain.strip() in ("stable", ""):
+            version = self._resolve_latest_lean_version()
+        else:
+            version = self._parse_lean4_version(toolchain)
+        if not version:
+            logger.error(f"GitHub fallback cannot handle toolchain spec: {toolchain!r}")
+            return False
+
+        arch = "_aarch64" if platform.machine().lower() in ("arm64", "aarch64") else ""
+        asset = f"lean-{version.lstrip('v')}-{self._system}{arch}.zip"
+        url = f"{self.LEAN4_RELEASES_URL}/download/{version}/{asset}"
+
+        self.ensure_directories()
+        archive = self.cache_dir / asset
+        if not archive.exists():
+            try:
+                _download_with_progress(url, archive, label=f"Downloading {asset}")
+            except Exception as e:
+                logger.error(f"Failed to download {url}: {e}")
+                archive.unlink(missing_ok=True)
+                return False
+
+        dest = self.app_dir / "toolchains" / archive.name[:-len(".zip")]
+        try:
+            _extract_zip_with_permissions(archive, dest)
+        except Exception as e:
+            logger.error(f"Failed to extract {archive}: {e}")
+            return False
+
+        # The archive contains a single top-level directory holding bin/lean
+        toolchain_root = dest if (dest / "bin").is_dir() else next(
+            (p for p in sorted(dest.iterdir()) if (p / "bin").is_dir()), None
+        )
+        if toolchain_root is None:
+            logger.error(f"No bin/ directory found in extracted archive at {dest}")
+            return False
+
+        name = f"leanprover/lean4:{version}"
+        for cmd in (
+            ["elan", "toolchain", "link", name, str(toolchain_root)],
+            ["elan", "default", name],
+        ):
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=60,
+                    env=self._get_env(),
+                )
+            except Exception as e:
+                logger.error(f"Error running {' '.join(cmd)}: {e}")
+                return False
+            if result.returncode != 0:
+                logger.error(f"{' '.join(cmd[:3])} failed: {result.stderr}")
+                return False
+
+        logger.info(f"Toolchain {name} installed from GitHub release")
+        return True
 
     def read_toolchain_file(self, repo_path: Path) -> Optional[str]:
         """Read and parse the lean-toolchain file from a repository.

--- a/src/sandbox.py
+++ b/src/sandbox.py
@@ -113,7 +113,7 @@ class Sandbox:
                 [lake_cmd, "init", "ErdosSandbox"],
                 cwd=self.work_dir,
                 capture_output=True, text=True, timeout=30,
-                env={**os.environ, "PATH": f"{lake_bin}:{os.environ.get('PATH', '')}"} if lake_bin else None,
+                env=_elan_env(lake_bin),
             )
             if result.returncode != 0:
                 logger.warning(f"lake init failed: {result.stderr[:200]}")
@@ -196,6 +196,22 @@ def _discover_elan_bin() -> Optional[Path]:
     return None
 
 
+def _elan_env(elan_bin: Optional[Path]) -> dict:
+    """Build a subprocess environment for elan-proxied binaries.
+
+    The proxies (lean/lake) resolve toolchains via ELAN_HOME, so when the
+    discovered install lives outside the default ~/.elan (e.g. the
+    app-isolated ~/.erdos-prover location), PATH alone is not enough —
+    the proxy would look for toolchains in ~/.elan and fail.
+    """
+    env = os.environ.copy()
+    if elan_bin:
+        path_sep = ";" if os.name == "nt" else ":"
+        env["PATH"] = str(elan_bin) + path_sep + env.get("PATH", "")
+        env["ELAN_HOME"] = str(elan_bin.parent)
+    return env
+
+
 def run_lake_build(
     work_dir: Path,
     timeout_seconds: int = 60,
@@ -219,13 +235,9 @@ def run_lake_build(
     if target:
         cmd.append(target)
     
-    # Discover elan bin directory and ensure it's in PATH
-    env = os.environ.copy()
+    # Discover elan bin directory; PATH and ELAN_HOME must both point at it
+    env = _elan_env(_discover_elan_bin())
     env["LAKE_NO_INTERACTIVE"] = "1"
-    elan_bin = _discover_elan_bin()
-    if elan_bin:
-        path_sep = ";" if os.name == "nt" else ":"
-        env["PATH"] = str(elan_bin) + path_sep + env.get("PATH", "")
 
     try:
         result = subprocess.run(

--- a/tests/test_real_data_validation.py
+++ b/tests/test_real_data_validation.py
@@ -31,7 +31,10 @@ from src.validator import (
     extract_theorem_statement, compute_theorem_hash,
     validate_theorem_integrity, run_security_check, TheoremLocker,
 )
-from src.sandbox import Sandbox, SandboxManager, BuildResult, run_lake_build
+from src.sandbox import (
+    Sandbox, SandboxManager, BuildResult, run_lake_build,
+    _discover_elan_bin, _elan_env,
+)
 from src.packager import package_artifact, list_solutions, get_solution
 from src.llm import LLMProvider, MockLLMProvider
 
@@ -112,14 +115,20 @@ theorem true_and_true : True ∧ True := by
 # ═══════════════════════════════════════════════════════════════════
 
 LEAN_AVAILABLE = False
-LEAN_BIN = Path.home() / ".elan" / "bin"
+# Use the same discovery as the production sandbox so these tests run
+# against whichever install exists (~/.elan or the app-isolated
+# ~/.erdos-prover location created by `python -m src.environment --install`).
+_ELAN_BIN = _discover_elan_bin()
+LEAN_BIN = _ELAN_BIN if _ELAN_BIN else Path.home() / ".elan" / "bin"
 LEAN_PATH = str(LEAN_BIN / "lean")
 LAKE_PATH = str(LEAN_BIN / "lake")
+LEAN_ENV = _elan_env(_ELAN_BIN)
 
 try:
     result = subprocess.run(
         [LEAN_PATH, "--version"],
         capture_output=True, text=True, timeout=10,
+        env=LEAN_ENV,
     )
     LEAN_AVAILABLE = result.returncode == 0
 except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -136,6 +145,7 @@ def _setup_lean_project():
             [LAKE_PATH, "init", "RealTest"],
             cwd=LEAN_PROJECT_DIR,
             capture_output=True, timeout=30,
+            env=LEAN_ENV,
         )
 
 
@@ -152,7 +162,7 @@ def _build_lean_file(content: str, filename: str = "Test.lean") -> BuildResult:
             cwd=LEAN_PROJECT_DIR,
             capture_output=True, text=True,
             timeout=120,
-            env={**os.environ, "PATH": f"{LEAN_BIN}:{os.environ.get('PATH', '')}"},
+            env=LEAN_ENV,
         )
         duration = __import__("time").time() - start
         return BuildResult(


### PR DESCRIPTION
## What

Proves the pipeline end-to-end against a **real Lean 4.30.0 toolchain** and fixes the bugs that were in the way. Full report in `VERIFICATION.md`.

- `environment.py`: elan binary install decoupled from toolchain install; **GitHub-release toolchain fallback** for networks that block `release.lean-lang.org` (resolves latest tag via the releases/latest redirect, downloads the official zip, extracts preserving Unix exec bits — `ZipFile.extractall` drops them — and registers via `elan toolchain link`).
- `sandbox.py` real bug: elan proxies resolve toolchains via `ELAN_HOME`, so PATH alone fails with the app-isolated install ("no default toolchain configured"). New `_elan_env()` sets both, used by `lake init` and `run_lake_build`.
- `tests/test_real_data_validation.py`: uses the sandbox's own discovery instead of hardcoding `~/.elan/bin`, so the project's installer makes the project's tests run.

## Verification (executed, not inferred)

- `python -m src.environment --install` → Lean 4.30.0 via the GitHub fallback (826 MB).
- **323 passed, 0 skipped** (was 314 + 9 skipped): the SHA-256 modified-theorem rejection and the full provider→hash→compile→critic→artifact pipeline now verified against the real compiler.
- Mock-mode mining run: all 4 example problems attempted; every candidate correctly killed at the integrity gate (mock output is scaffolding by design).

Part of the project-wide polish batch.

https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAKnLjpFZ9oF74GNW9QNtN)_